### PR TITLE
Implement game CRUD and enhanced user registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "seed": "ts-node src/seed.ts"
   },
   "dependencies": {
     "@apollo/server": "^4.12.1",

--- a/src/games/application/dto/update-game.input.ts
+++ b/src/games/application/dto/update-game.input.ts
@@ -1,0 +1,39 @@
+import { InputType, Field, ID, Int } from '@nestjs/graphql';
+import { IsString, IsOptional, IsUrl, IsInt, Min, Max } from 'class-validator';
+
+@InputType()
+export class UpdateGameInput {
+  @Field(() => ID)
+  id: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  genre?: string;
+
+  @Field(() => [String], { nullable: true })
+  @IsOptional()
+  platforms?: string[];
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsUrl()
+  coverUrl?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  developer?: string;
+
+  @Field(() => Int, { nullable: true })
+  @IsOptional()
+  @IsInt()
+  @Min(1970)
+  @Max(new Date().getFullYear() + 5)
+  releaseYear?: number;
+}

--- a/src/games/domain/repositories/game.repository.ts
+++ b/src/games/domain/repositories/game.repository.ts
@@ -6,4 +6,12 @@ export interface IGameRepository {
   create(game: Partial<GameEntity>): Promise<GameEntity>;
 
   findAll(): Promise<GameEntity[]>;
+
+  findById(id: string): Promise<GameEntity | null>;
+
+  searchByName(name: string): Promise<GameEntity[]>;
+
+  update(id: string, data: Partial<GameEntity>): Promise<GameEntity | null>;
+
+  delete(id: string): Promise<boolean>;
 }

--- a/src/games/domain/services/delete-game.usecase.ts
+++ b/src/games/domain/services/delete-game.usecase.ts
@@ -1,0 +1,16 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { GAME_REPOSITORY, IGameRepository } from '../repositories/game.repository';
+
+@Injectable()
+export class DeleteGameUseCase {
+  constructor(
+    @Inject(GAME_REPOSITORY)
+    private readonly gameRepository: IGameRepository,
+  ) {}
+
+  async execute(id: string): Promise<boolean> {
+    const deleted = await this.gameRepository.delete(id);
+    if (!deleted) throw new NotFoundException('Juego no encontrado');
+    return true;
+  }
+}

--- a/src/games/domain/services/find-game-by-id.usecase.ts
+++ b/src/games/domain/services/find-game-by-id.usecase.ts
@@ -1,0 +1,17 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { GAME_REPOSITORY, IGameRepository } from '../repositories/game.repository';
+import { GameEntity } from '../entities/game.entity';
+
+@Injectable()
+export class FindGameByIdUseCase {
+  constructor(
+    @Inject(GAME_REPOSITORY)
+    private readonly gameRepository: IGameRepository,
+  ) {}
+
+  async execute(id: string): Promise<GameEntity> {
+    const game = await this.gameRepository.findById(id);
+    if (!game) throw new NotFoundException('Juego no encontrado');
+    return game;
+  }
+}

--- a/src/games/domain/services/search-games-by-name.usecase.spec.ts
+++ b/src/games/domain/services/search-games-by-name.usecase.spec.ts
@@ -1,0 +1,20 @@
+import { SearchGamesByNameUseCase } from './search-games-by-name.usecase';
+import { GAME_REPOSITORY, IGameRepository } from '../repositories/game.repository';
+
+describe('SearchGamesByNameUseCase', () => {
+  it('returns games from repository', async () => {
+    const repo: jest.Mocked<IGameRepository> = {
+      create: jest.fn(),
+      findAll: jest.fn(),
+      findById: jest.fn(),
+      searchByName: jest.fn().mockResolvedValue([{ id: '1', name: 'Game' }] as any),
+      update: jest.fn(),
+      delete: jest.fn(),
+    } as any;
+
+    const useCase = new SearchGamesByNameUseCase(repo);
+    const result = await useCase.execute('ga');
+    expect(repo.searchByName).toHaveBeenCalledWith('ga');
+    expect(result[0].id).toBe('1');
+  });
+});

--- a/src/games/domain/services/search-games-by-name.usecase.ts
+++ b/src/games/domain/services/search-games-by-name.usecase.ts
@@ -1,0 +1,15 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { GAME_REPOSITORY, IGameRepository } from '../repositories/game.repository';
+import { GameEntity } from '../entities/game.entity';
+
+@Injectable()
+export class SearchGamesByNameUseCase {
+  constructor(
+    @Inject(GAME_REPOSITORY)
+    private readonly gameRepository: IGameRepository,
+  ) {}
+
+  async execute(name: string): Promise<GameEntity[]> {
+    return this.gameRepository.searchByName(name);
+  }
+}

--- a/src/games/domain/services/update-game.usecase.ts
+++ b/src/games/domain/services/update-game.usecase.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { GAME_REPOSITORY, IGameRepository } from '../repositories/game.repository';
+import { GameEntity } from '../entities/game.entity';
+import { UpdateGameInput } from '../../application/dto/update-game.input';
+
+@Injectable()
+export class UpdateGameUseCase {
+  constructor(
+    @Inject(GAME_REPOSITORY)
+    private readonly gameRepository: IGameRepository,
+  ) {}
+
+  async execute(input: UpdateGameInput): Promise<GameEntity> {
+    const updated = await this.gameRepository.update(input.id, { ...input });
+    if (!updated) throw new NotFoundException('Juego no encontrado');
+    return updated;
+  }
+}

--- a/src/games/games.module.ts
+++ b/src/games/games.module.ts
@@ -9,6 +9,10 @@ import { CreateGameUseCase } from './domain/services/create-game.usecase';
 import { FindAllGamesUseCase } from './domain/services/find-all-games.usecase';
 import { GameRepositoryImpl } from './infrastructure/database/game.repository.impl';
 import { GAME_REPOSITORY } from './domain/repositories/game.repository';
+import { FindGameByIdUseCase } from './domain/services/find-game-by-id.usecase';
+import { SearchGamesByNameUseCase } from './domain/services/search-games-by-name.usecase';
+import { UpdateGameUseCase } from './domain/services/update-game.usecase';
+import { DeleteGameUseCase } from './domain/services/delete-game.usecase';
 
 @Module({
   imports: [
@@ -18,11 +22,15 @@ import { GAME_REPOSITORY } from './domain/repositories/game.repository';
     GamesResolver,
     CreateGameUseCase,
     FindAllGamesUseCase,
+    FindGameByIdUseCase,
+    SearchGamesByNameUseCase,
+    UpdateGameUseCase,
+    DeleteGameUseCase,
     {
       provide: GAME_REPOSITORY,
       useClass: GameRepositoryImpl,
     },
   ],
-  exports: [],
+  exports: [GAME_REPOSITORY],
 })
 export class GamesModule {}

--- a/src/games/infrastructure/database/game.repository.impl.ts
+++ b/src/games/infrastructure/database/game.repository.impl.ts
@@ -37,4 +37,54 @@ export class GameRepositoryImpl implements IGameRepository {
         ),
     );
   }
+
+  async findById(id: string): Promise<GameEntity | null> {
+    const g = await this.model.findById(id);
+    if (!g) return null;
+    return new GameEntity(
+      (g._id as any).toString(),
+      g.name,
+      g.genre,
+      g.platforms,
+      g.coverUrl,
+      g.developer,
+      g.releaseYear,
+    );
+  }
+
+  async searchByName(name: string): Promise<GameEntity[]> {
+    const regex = new RegExp(name, 'i');
+    const games = await this.model.find({ name: regex });
+    return games.map(
+      (g) =>
+        new GameEntity(
+          (g._id as any).toString(),
+          g.name,
+          g.genre,
+          g.platforms,
+          g.coverUrl,
+          g.developer,
+          g.releaseYear,
+        ),
+    );
+  }
+
+  async update(id: string, data: Partial<GameEntity>): Promise<GameEntity | null> {
+    const updated = await this.model.findByIdAndUpdate(id, data, { new: true });
+    if (!updated) return null;
+    return new GameEntity(
+      (updated._id as any).toString(),
+      updated.name,
+      updated.genre,
+      updated.platforms,
+      updated.coverUrl,
+      updated.developer,
+      updated.releaseYear,
+    );
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const res = await this.model.findByIdAndDelete(id);
+    return !!res;
+  }
 }

--- a/src/games/resolvers/games.resolver.ts
+++ b/src/games/resolvers/games.resolver.ts
@@ -1,14 +1,23 @@
 import { Resolver, Mutation, Args, Query } from '@nestjs/graphql';
 import { CreateGameInput } from '../application/dto/create-game.input';
+import { UpdateGameInput } from '../application/dto/update-game.input';
 import { GameOutput } from '../application/dto/game.output';
 import { CreateGameUseCase } from '../domain/services/create-game.usecase';
 import { FindAllGamesUseCase } from '../domain/services/find-all-games.usecase';
+import { FindGameByIdUseCase } from '../domain/services/find-game-by-id.usecase';
+import { SearchGamesByNameUseCase } from '../domain/services/search-games-by-name.usecase';
+import { UpdateGameUseCase } from '../domain/services/update-game.usecase';
+import { DeleteGameUseCase } from '../domain/services/delete-game.usecase';
 
 @Resolver(() => GameOutput)
 export class GamesResolver {
   constructor(
     private readonly createGameUseCase: CreateGameUseCase,
     private readonly findAllGamesUseCase: FindAllGamesUseCase,
+    private readonly findGameByIdUseCase: FindGameByIdUseCase,
+    private readonly searchGamesByNameUseCase: SearchGamesByNameUseCase,
+    private readonly updateGameUseCase: UpdateGameUseCase,
+    private readonly deleteGameUseCase: DeleteGameUseCase,
   ) {}
 
   @Mutation(() => GameOutput)
@@ -31,5 +40,28 @@ export class GamesResolver {
   async getAllGames(): Promise<GameOutput[]> {
     const games = await this.findAllGamesUseCase.execute();
     return games.map((g) => ({ ...g }));
+  }
+
+  @Query(() => GameOutput)
+  async getGameById(@Args('id') id: string): Promise<GameOutput> {
+    const game = await this.findGameByIdUseCase.execute(id);
+    return { ...game };
+  }
+
+  @Query(() => [GameOutput])
+  async searchGamesByName(@Args('name') name: string): Promise<GameOutput[]> {
+    const games = await this.searchGamesByNameUseCase.execute(name);
+    return games.map((g) => ({ ...g }));
+  }
+
+  @Mutation(() => GameOutput)
+  async updateGame(@Args('input') input: UpdateGameInput): Promise<GameOutput> {
+    const game = await this.updateGameUseCase.execute(input);
+    return { ...game };
+  }
+
+  @Mutation(() => Boolean)
+  async deleteGame(@Args('id') id: string): Promise<boolean> {
+    return this.deleteGameUseCase.execute(id);
   }
 }

--- a/src/seed.ts
+++ b/src/seed.ts
@@ -1,0 +1,60 @@
+import { connect, connection, model } from 'mongoose';
+import { Game, GameSchema } from './games/infrastructure/database/schemas/game.schema';
+import { User, UserSchema } from './users/infrastructure/database/schemas/user.schema';
+import { randomBytes, scryptSync } from 'crypto';
+
+async function run() {
+  const uri = process.env.MONGO_URI || 'mongodb://localhost:27017/gamecrush';
+  await connect(uri);
+
+  const GameModel = model(Game.name, GameSchema);
+  const UserModel = model(User.name, UserSchema);
+
+  await GameModel.deleteMany({});
+  await UserModel.deleteMany({});
+
+  const games = await GameModel.insertMany([
+    { name: 'Valorant' },
+    { name: 'Fortnite' },
+    { name: 'Minecraft' },
+    { name: 'League of Legends' },
+    { name: 'Apex Legends' },
+  ]);
+
+  const salt = randomBytes(8).toString('hex');
+  const hash = scryptSync('password', salt, 32).toString('hex');
+  const password = `${salt}.${hash}`;
+
+  await UserModel.insertMany([
+    {
+      gamerTag: 'gamer1',
+      email: 'gamer1@example.com',
+      password,
+      favoriteGames: [games[0]._id, games[1]._id],
+      platforms: ['PC'],
+      styleOfPlay: 'Casual',
+      availability: ['Noche'],
+      languages: ['es'],
+      termsAccepted: true,
+    },
+    {
+      gamerTag: 'gamer2',
+      email: 'gamer2@example.com',
+      password,
+      favoriteGames: [games[2]._id],
+      platforms: ['PS5'],
+      styleOfPlay: 'Competitivo',
+      availability: ['Fines de semana'],
+      languages: ['es', 'en'],
+      termsAccepted: true,
+    },
+  ]);
+
+  console.log('Seed data inserted');
+  await connection.close();
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/users/application/dto/create-user.input.ts
+++ b/src/users/application/dto/create-user.input.ts
@@ -6,6 +6,7 @@ import {
   IsBoolean,
   IsArray,
   IsUrl,
+  IsIn,
   MinLength,
 } from 'class-validator';
 
@@ -31,12 +32,29 @@ export class CreateUserInput {
   @Field(() => [String], { nullable: true })
   @IsOptional()
   @IsArray()
+  @IsIn(['PC', 'PS5', 'XBOX', 'SWITCH', 'MOBILE'], { each: true })
   platforms?: string[];
 
   @Field(() => [String], { nullable: true })
   @IsOptional()
   @IsArray()
   genres?: string[];
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsIn(['Casual', 'Competitivo', 'Cooperativo'])
+  styleOfPlay?: string;
+
+  @Field(() => [String], { nullable: true })
+  @IsOptional()
+  @IsArray()
+  @IsIn(['Manana', 'Tarde', 'Noche', 'Fines de semana'], { each: true })
+  availability?: string[];
+
+  @Field(() => [String], { nullable: true })
+  @IsOptional()
+  @IsArray()
+  languages?: string[];
 
   @Field({ nullable: true })
   @IsOptional()
@@ -57,6 +75,10 @@ export class CreateUserInput {
   @IsOptional()
   @IsBoolean()
   showGamerTag?: boolean;
+
+  @Field()
+  @IsBoolean()
+  termsAccepted: boolean;
 
   @Field(() => [String], { nullable: true })
   @IsOptional()

--- a/src/users/application/dto/user.output.ts
+++ b/src/users/application/dto/user.output.ts
@@ -20,4 +20,9 @@ export class UserOutput {
   @Field() showGamerTag: boolean;
 
   @Field(() => [String]) photos: string[];
+
+  @Field() styleOfPlay: string;
+  @Field(() => [String]) availability: string[];
+  @Field(() => [String]) languages: string[];
+  @Field() termsAccepted: boolean;
 }

--- a/src/users/domain/entities/user.entity.ts
+++ b/src/users/domain/entities/user.entity.ts
@@ -12,5 +12,9 @@ export class UserEntity {
     public readonly hasMic: boolean = false,
     public readonly showGamerTag: boolean = true,
     public readonly photos: string[] = [],
+    public readonly styleOfPlay: string = 'Casual',
+    public readonly availability: string[] = [],
+    public readonly languages: string[] = [],
+    public readonly termsAccepted: boolean = false,
   ) {}
 }

--- a/src/users/domain/repositories/user.repository.ts
+++ b/src/users/domain/repositories/user.repository.ts
@@ -5,4 +5,5 @@ export const USER_REPOSITORY = Symbol('USER_REPOSITORY');
 export abstract class IUserRepository {
   abstract create(user: Partial<UserEntity>): Promise<UserEntity>;
   abstract findByEmail(email: string): Promise<UserEntity | null>;
+  abstract findByGamerTag(gamerTag: string): Promise<UserEntity | null>;
 }

--- a/src/users/domain/services/create-user.usecase.spec.ts
+++ b/src/users/domain/services/create-user.usecase.spec.ts
@@ -1,0 +1,76 @@
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { CreateUserUseCase } from './create-user.usecase';
+import { CreateUserInput } from '../../application/dto/create-user.input';
+import { USER_REPOSITORY, IUserRepository } from '../repositories/user.repository';
+import { GAME_REPOSITORY, IGameRepository } from '../../../games/domain/repositories/game.repository';
+
+const baseInput: CreateUserInput = {
+  gamerTag: 'Player1',
+  email: 'test@example.com',
+  password: 'secret',
+  favoriteGames: ['1'],
+  platforms: ['PC'],
+  genres: [],
+  country: 'GT',
+  available: true,
+  hasMic: true,
+  showGamerTag: true,
+  photos: [],
+  styleOfPlay: 'Casual',
+  availability: ['Manana'],
+  languages: ['es'],
+  termsAccepted: true,
+};
+
+describe('CreateUserUseCase', () => {
+  let useCase: CreateUserUseCase;
+  let userRepo: jest.Mocked<IUserRepository>;
+  let gameRepo: jest.Mocked<IGameRepository>;
+
+  beforeEach(() => {
+    userRepo = {
+      create: jest.fn(),
+      findByEmail: jest.fn(),
+      findByGamerTag: jest.fn(),
+    } as any;
+    gameRepo = {
+      create: jest.fn(),
+      findAll: jest.fn(),
+      findById: jest.fn(),
+      searchByName: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    } as any;
+
+    useCase = new CreateUserUseCase(userRepo, gameRepo);
+  });
+
+  it('should create user with hashed password', async () => {
+    userRepo.findByEmail.mockResolvedValue(null);
+    userRepo.findByGamerTag.mockResolvedValue(null);
+    gameRepo.findById.mockResolvedValue({ id: '1', name: 'Game' } as any);
+    userRepo.create.mockImplementation(async (u) => u as any);
+
+    const result = await useCase.execute({ ...baseInput });
+    expect(result.password).not.toBe(baseInput.password);
+    expect(userRepo.create).toHaveBeenCalled();
+  });
+
+  it('should throw when email exists', async () => {
+    userRepo.findByEmail.mockResolvedValue({} as any);
+    await expect(useCase.execute({ ...baseInput })).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('should throw when gamerTag exists', async () => {
+    userRepo.findByEmail.mockResolvedValue(null);
+    userRepo.findByGamerTag.mockResolvedValue({} as any);
+    await expect(useCase.execute({ ...baseInput })).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('should throw when game does not exist', async () => {
+    userRepo.findByEmail.mockResolvedValue(null);
+    userRepo.findByGamerTag.mockResolvedValue(null);
+    gameRepo.findById.mockResolvedValue(null);
+    await expect(useCase.execute({ ...baseInput })).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/src/users/domain/services/create-user.usecase.ts
+++ b/src/users/domain/services/create-user.usecase.ts
@@ -1,24 +1,50 @@
-import { Inject, Injectable, ConflictException } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
 import { CreateUserInput } from '../../application/dto/create-user.input';
 import {
   IUserRepository,
   USER_REPOSITORY,
 } from '../repositories/user.repository';
 import { UserEntity } from '../entities/user.entity';
+import { GAME_REPOSITORY, IGameRepository } from '../../../games/domain/repositories/game.repository';
+import { scryptSync, randomBytes } from 'crypto';
 
 @Injectable()
 export class CreateUserUseCase {
   constructor(
     @Inject(USER_REPOSITORY)
     private readonly userRepository: IUserRepository,
+    @Inject(GAME_REPOSITORY)
+    private readonly gameRepository: IGameRepository,
   ) {}
 
   async execute(data: CreateUserInput): Promise<UserEntity> {
-    const existing = await this.userRepository.findByEmail(data.email);
-    if (existing) {
+    const emailExists = await this.userRepository.findByEmail(data.email);
+    if (emailExists) {
       throw new ConflictException('El correo ya está registrado');
     }
+    const tagExists = await this.userRepository.findByGamerTag(data.gamerTag);
+    if (tagExists) {
+      throw new ConflictException('El GamerTag ya está registrado');
+    }
 
-    return this.userRepository.create(data);
+    if (data.favoriteGames?.length) {
+      for (const id of data.favoriteGames) {
+        const exists = await this.gameRepository.findById(id);
+        if (!exists) {
+          throw new NotFoundException(`Juego no encontrado: ${id}`);
+        }
+      }
+    }
+
+    const salt = randomBytes(8).toString('hex');
+    const hash = scryptSync(data.password, salt, 32).toString('hex');
+    const hashed = `${salt}.${hash}`;
+
+    return this.userRepository.create({ ...data, password: hashed });
   }
 }

--- a/src/users/infrastructure/database/schemas/user.schema.ts
+++ b/src/users/infrastructure/database/schemas/user.schema.ts
@@ -35,6 +35,18 @@ export class User {
 
   @Prop({ type: [String], default: [] })
   photos: string[]; // URLs
+
+  @Prop({ default: 'Casual' })
+  styleOfPlay: string;
+
+  @Prop({ type: [String], default: [] })
+  availability: string[];
+
+  @Prop({ type: [String], default: [] })
+  languages: string[];
+
+  @Prop({ default: false })
+  termsAccepted: boolean;
 }
 
 export type UserDocument = User & Document;

--- a/src/users/infrastructure/database/user.repository.impl.ts
+++ b/src/users/infrastructure/database/user.repository.impl.ts
@@ -21,4 +21,9 @@ export class UserRepositoryImpl implements IUserRepository {
     if (!doc) return null;
     return UserMapper.toEntity(doc);
   }
+
+  async findByGamerTag(gamerTag: string): Promise<UserEntity | null> {
+    const doc = await this.model.findOne({ gamerTag });
+    return doc ? UserMapper.toEntity(doc) : null;
+  }
 }

--- a/src/users/infrastructure/mappers/user.mapper.ts
+++ b/src/users/infrastructure/mappers/user.mapper.ts
@@ -19,6 +19,10 @@ export class UserMapper {
       doc.hasMic,
       doc.showGamerTag,
       doc.photos,
+      doc.styleOfPlay,
+      doc.availability,
+      doc.languages,
+      doc.termsAccepted,
     );
   }
 
@@ -38,6 +42,10 @@ export class UserMapper {
       hasMic: entity.hasMic ?? false,
       showGamerTag: entity.showGamerTag ?? true,
       photos: entity.photos ?? [],
+      styleOfPlay: entity.styleOfPlay ?? 'Casual',
+      availability: entity.availability ?? [],
+      languages: entity.languages ?? [],
+      termsAccepted: entity.termsAccepted ?? false,
     };
   }
 }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -9,10 +9,12 @@ import {
 } from './infrastructure/database/schemas/user.schema';
 import { UserRepositoryImpl } from './infrastructure/database/user.repository.impl';
 import { USER_REPOSITORY } from './domain/repositories/user.repository';
+import { GamesModule } from '../games/games.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
+    GamesModule,
   ],
   providers: [
     UsersResolver,


### PR DESCRIPTION
## Summary
- add game search, update and delete features
- extend user registration with more fields and validations
- hash user password during creation
- provide seed script with example data
- add unit tests for new use cases

## Testing
- `npm run build`
- `npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6840888f2b18832aacddde949632ac0a