### PR TITLE
Implement game name mapping in CreateUser

### DIFF
--- a/src/games/domain/repositories/game.repository.ts
+++ b/src/games/domain/repositories/game.repository.ts
@@ -11,6 +11,8 @@ export interface IGameRepository {
 
   searchByName(name: string): Promise<GameEntity[]>;
 
+  findByNames(names: string[]): Promise<GameEntity[]>;
+
   update(id: string, data: Partial<GameEntity>): Promise<GameEntity | null>;
 
   delete(id: string): Promise<boolean>;

--- a/src/games/domain/services/search-games-by-name.usecase.spec.ts
+++ b/src/games/domain/services/search-games-by-name.usecase.spec.ts
@@ -8,6 +8,7 @@ describe('SearchGamesByNameUseCase', () => {
       findAll: jest.fn(),
       findById: jest.fn(),
       searchByName: jest.fn().mockResolvedValue([{ id: '1', name: 'Game' }] as any),
+      findByNames: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),
     } as any;

--- a/src/games/infrastructure/database/game.repository.impl.ts
+++ b/src/games/infrastructure/database/game.repository.impl.ts
@@ -69,6 +69,22 @@ export class GameRepositoryImpl implements IGameRepository {
     );
   }
 
+  async findByNames(names: string[]): Promise<GameEntity[]> {
+    const games = await this.model.find({ name: { $in: names } });
+    return games.map(
+      (g) =>
+        new GameEntity(
+          (g._id as any).toString(),
+          g.name,
+          g.genre,
+          g.platforms,
+          g.coverUrl,
+          g.developer,
+          g.releaseYear,
+        ),
+    );
+  }
+
   async update(id: string, data: Partial<GameEntity>): Promise<GameEntity | null> {
     const updated = await this.model.findByIdAndUpdate(id, data, { new: true });
     if (!updated) return null;

--- a/src/users/application/dto/create-user.input.spec.ts
+++ b/src/users/application/dto/create-user.input.spec.ts
@@ -1,0 +1,18 @@
+import { validate } from 'class-validator';
+import { CreateUserInput } from './create-user.input';
+
+describe('CreateUserInput validation', () => {
+  it('fails when favoriteGames contains non-string values', async () => {
+    const input = new CreateUserInput();
+    Object.assign(input, {
+      gamerTag: 'Player',
+      email: 'test@example.com',
+      password: 'secret',
+      favoriteGames: [123 as any],
+      termsAccepted: true,
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/src/users/application/dto/create-user.input.ts
+++ b/src/users/application/dto/create-user.input.ts
@@ -27,6 +27,7 @@ export class CreateUserInput {
   @Field(() => [String], { nullable: true })
   @IsOptional()
   @IsArray()
+  @IsString({ each: true })
   favoriteGames?: string[];
 
   @Field(() => [String], { nullable: true })

--- a/src/users/domain/services/create-user.usecase.spec.ts
+++ b/src/users/domain/services/create-user.usecase.spec.ts
@@ -8,7 +8,7 @@ const baseInput: CreateUserInput = {
   gamerTag: 'Player1',
   email: 'test@example.com',
   password: 'secret',
-  favoriteGames: ['1'],
+  favoriteGames: ['Valorant'],
   platforms: ['PC'],
   genres: [],
   country: 'GT',
@@ -36,8 +36,8 @@ describe('CreateUserUseCase', () => {
     gameRepo = {
       create: jest.fn(),
       findAll: jest.fn(),
-      findById: jest.fn(),
       searchByName: jest.fn(),
+      findByNames: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),
     } as any;
@@ -48,11 +48,12 @@ describe('CreateUserUseCase', () => {
   it('should create user with hashed password', async () => {
     userRepo.findByEmail.mockResolvedValue(null);
     userRepo.findByGamerTag.mockResolvedValue(null);
-    gameRepo.findById.mockResolvedValue({ id: '1', name: 'Game' } as any);
+    gameRepo.findByNames.mockResolvedValue([{ id: '1', name: 'Valorant' }] as any);
     userRepo.create.mockImplementation(async (u) => u as any);
 
     const result = await useCase.execute({ ...baseInput });
     expect(result.password).not.toBe(baseInput.password);
+    expect(result.favoriteGames).toEqual(['1']);
     expect(userRepo.create).toHaveBeenCalled();
   });
 
@@ -70,7 +71,7 @@ describe('CreateUserUseCase', () => {
   it('should throw when game does not exist', async () => {
     userRepo.findByEmail.mockResolvedValue(null);
     userRepo.findByGamerTag.mockResolvedValue(null);
-    gameRepo.findById.mockResolvedValue(null);
+    gameRepo.findByNames.mockResolvedValue([]);
     await expect(useCase.execute({ ...baseInput })).rejects.toBeInstanceOf(NotFoundException);
   });
 });

--- a/src/users/domain/services/create-user.usecase.ts
+++ b/src/users/domain/services/create-user.usecase.ts
@@ -32,19 +32,25 @@ export class CreateUserUseCase {
       throw new ConflictException('El GamerTag ya está registrado');
     }
 
+    let favoriteGameIds: string[] = [];
     if (data.favoriteGames?.length) {
-      for (const id of data.favoriteGames) {
-        const exists = await this.gameRepository.findById(id);
-        if (!exists) {
-          throw new NotFoundException(`Juego no encontrado: ${id}`);
-        }
+      const games = await this.gameRepository.findByNames(data.favoriteGames);
+      if (games.length !== data.favoriteGames.length) {
+        const found = games.map((g) => g.name);
+        const missing = data.favoriteGames.filter((n) => !found.includes(n));
+        throw new NotFoundException(`Juego no encontrado: ${missing.join(', ')}`);
       }
+      favoriteGameIds = games.map((g) => g.id);
     }
 
     const salt = randomBytes(8).toString('hex');
     const hash = scryptSync(data.password, salt, 32).toString('hex');
     const hashed = `${salt}.${hash}`;
 
-    return this.userRepository.create({ ...data, password: hashed });
+    return this.userRepository.create({
+      ...data,
+      favoriteGames: favoriteGameIds,
+      password: hashed,
+    });
   }
 }

--- a/src/users/resolvers/users.resolver.spec.ts
+++ b/src/users/resolvers/users.resolver.spec.ts
@@ -1,0 +1,22 @@
+import { UsersResolver } from './users.resolver';
+import { CreateUserUseCase } from '../domain/services/create-user.usecase';
+import { FindUserByEmailUseCase } from '../domain/services/find-user-by-email.usecase';
+
+describe('UsersResolver', () => {
+  it('calls CreateUserUseCase on createUser', async () => {
+    const create = { execute: jest.fn().mockResolvedValue({ id: '1' }) } as unknown as CreateUserUseCase;
+    const find = {} as FindUserByEmailUseCase;
+    const resolver = new UsersResolver(create, find);
+    const input: any = { gamerTag: 'tag', email: 'e@mail.com', password: 'pass', termsAccepted: true };
+    await resolver.createUser(input);
+    expect(create.execute).toHaveBeenCalledWith(input);
+  });
+
+  it('calls FindUserByEmailUseCase on getUserByEmail', async () => {
+    const create = {} as CreateUserUseCase;
+    const find = { execute: jest.fn().mockResolvedValue({ id: '1' }) } as unknown as FindUserByEmailUseCase;
+    const resolver = new UsersResolver(create, find);
+    await resolver.getUserByEmail({ email: 'test@example.com' });
+    expect(find.execute).toHaveBeenCalledWith('test@example.com');
+  });
+});


### PR DESCRIPTION
## Summary
- validate favorite game names in `CreateUserInput`
- map favorite game names to ids when creating user
- add `findByNames` to `IGameRepository` and its Mongo implementation
- adjust unit tests for create user use case
- add validation and resolver tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68409bb7afb8832a8b4f2644ec24d2fa