### PR TITLE
Add validation messages and GraphQL error filter

### DIFF
--- a/src/common/filters/graphql-exception.filter.ts
+++ b/src/common/filters/graphql-exception.filter.ts
@@ -1,0 +1,25 @@
+import { ArgumentsHost, Catch, ExceptionFilter, BadRequestException, Logger } from '@nestjs/common';
+import { GqlArgumentsHost } from '@nestjs/graphql';
+import { GraphQLError } from 'graphql';
+
+@Catch()
+export class GraphQLExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(GraphQLExceptionFilter.name);
+
+  catch(exception: any, host: ArgumentsHost) {
+    const gqlHost = GqlArgumentsHost.create(host);
+    this.logger.error('GraphQL Exception:', exception);
+
+    if (exception instanceof BadRequestException) {
+      const response = exception.getResponse();
+      const message = (response as any).message || 'Bad Request';
+      return new GraphQLError(Array.isArray(message) ? message.join(', ') : message);
+    }
+
+    if (exception.message) {
+      return new GraphQLError(exception.message);
+    }
+
+    return new GraphQLError('Internal Server Error');
+  }
+}

--- a/src/games/application/dto/create-game.input.ts
+++ b/src/games/application/dto/create-game.input.ts
@@ -13,35 +13,35 @@ import {
 @InputType()
 export class CreateGameInput {
   @Field()
-  @IsString()
+  @IsString({ message: 'El nombre del juego debe ser una cadena de texto' })
   name: string;
 
   @Field({ nullable: true })
   @IsOptional()
-  @IsString()
+  @IsString({ message: 'El género debe ser una cadena de texto' })
   genre?: string;
 
   @Field(() => [String], { nullable: true })
   @IsOptional()
-  @IsArray()
-  @ArrayNotEmpty()
-  @IsString({ each: true })
+  @IsArray({ message: 'platforms debe ser un arreglo' })
+  @ArrayNotEmpty({ message: 'Debe especificar al menos una plataforma' })
+  @IsString({ each: true, message: 'Cada plataforma debe ser una cadena de texto' })
   platforms?: string[];
 
   @Field({ nullable: true })
   @IsOptional()
-  @IsUrl()
+  @IsUrl({}, { message: 'La URL de la portada no es válida' })
   coverUrl?: string;
 
   @Field({ nullable: true })
   @IsOptional()
-  @IsString()
+  @IsString({ message: 'El desarrollador debe ser una cadena de texto' })
   developer?: string;
 
   @Field(() => Int, { nullable: true })
   @IsOptional()
-  @IsInt()
-  @Min(1970)
-  @Max(new Date().getFullYear() + 5) // opcional: límites razonables
+  @IsInt({ message: 'El año de lanzamiento debe ser un número entero' })
+  @Min(1970, { message: 'El año de lanzamiento no puede ser menor a 1970' })
+  @Max(new Date().getFullYear() + 5, { message: 'El año de lanzamiento es demasiado alto' }) // opcional: límites razonables
   releaseYear?: number;
 }

--- a/src/games/application/dto/update-game.input.ts
+++ b/src/games/application/dto/update-game.input.ts
@@ -8,12 +8,12 @@ export class UpdateGameInput {
 
   @Field({ nullable: true })
   @IsOptional()
-  @IsString()
+  @IsString({ message: 'El nombre del juego debe ser una cadena de texto' })
   name?: string;
 
   @Field({ nullable: true })
   @IsOptional()
-  @IsString()
+  @IsString({ message: 'El género debe ser una cadena de texto' })
   genre?: string;
 
   @Field(() => [String], { nullable: true })
@@ -22,18 +22,18 @@ export class UpdateGameInput {
 
   @Field({ nullable: true })
   @IsOptional()
-  @IsUrl()
+  @IsUrl({}, { message: 'La URL de la portada no es válida' })
   coverUrl?: string;
 
   @Field({ nullable: true })
   @IsOptional()
-  @IsString()
+  @IsString({ message: 'El desarrollador debe ser una cadena de texto' })
   developer?: string;
 
   @Field(() => Int, { nullable: true })
   @IsOptional()
-  @IsInt()
-  @Min(1970)
-  @Max(new Date().getFullYear() + 5)
+  @IsInt({ message: 'El año de lanzamiento debe ser un número entero' })
+  @Min(1970, { message: 'El año de lanzamiento no puede ser menor a 1970' })
+  @Max(new Date().getFullYear() + 5, { message: 'El año de lanzamiento es demasiado alto' })
   releaseYear?: number;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { GraphQLExceptionFilter } from './common/filters/graphql-exception.filter';
 import { ConfigService } from '@nestjs/config';
 
 async function bootstrap() {
@@ -23,6 +24,8 @@ async function bootstrap() {
       },
     }),
   );
+
+  app.useGlobalFilters(new GraphQLExceptionFilter());
 
   await app.listen(configService.get<number>('PORT') || 3000);
 }

--- a/src/users/application/dto/create-user.input.ts
+++ b/src/users/application/dto/create-user.input.ts
@@ -13,77 +13,85 @@ import {
 @InputType()
 export class CreateUserInput {
   @Field()
-  @IsString()
+  @IsString({ message: 'El gamerTag debe ser una cadena de texto' })
   gamerTag: string;
 
   @Field()
-  @IsEmail()
+  @IsEmail({}, { message: 'El correo electrónico no es válido' })
   email: string;
 
   @Field()
-  @MinLength(6)
+  @MinLength(6, { message: 'La contraseña debe tener al menos 6 caracteres' })
   password: string;
 
   @Field(() => [String], { nullable: true })
   @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
+  @IsArray({ message: 'favoriteGames debe ser un arreglo' })
+  @IsString({ each: true, message: 'Cada juego favorito debe ser una cadena' })
   favoriteGames?: string[];
 
   @Field(() => [String], { nullable: true })
   @IsOptional()
-  @IsArray()
-  @IsIn(['PC', 'PS5', 'XBOX', 'SWITCH', 'MOBILE'], { each: true })
+  @IsArray({ message: 'platforms debe ser un arreglo' })
+  @IsIn(['PC', 'PS5', 'XBOX', 'SWITCH', 'MOBILE'], {
+    each: true,
+    message: 'Plataforma no válida',
+  })
   platforms?: string[];
 
   @Field(() => [String], { nullable: true })
   @IsOptional()
-  @IsArray()
+  @IsArray({ message: 'genres debe ser un arreglo' })
   genres?: string[];
 
   @Field({ nullable: true })
   @IsOptional()
-  @IsIn(['Casual', 'Competitivo', 'Cooperativo'])
+  @IsIn(['Casual', 'Competitivo', 'Cooperativo'], {
+    message: 'Estilo de juego no válido',
+  })
   styleOfPlay?: string;
 
   @Field(() => [String], { nullable: true })
   @IsOptional()
-  @IsArray()
-  @IsIn(['Manana', 'Tarde', 'Noche', 'Fines de semana'], { each: true })
+  @IsArray({ message: 'availability debe ser un arreglo' })
+  @IsIn(['Manana', 'Tarde', 'Noche', 'Fines de semana'], {
+    each: true,
+    message: 'Disponibilidad no válida',
+  })
   availability?: string[];
 
   @Field(() => [String], { nullable: true })
   @IsOptional()
-  @IsArray()
+  @IsArray({ message: 'languages debe ser un arreglo' })
   languages?: string[];
 
   @Field({ nullable: true })
   @IsOptional()
-  @IsString()
+  @IsString({ message: 'El país debe ser una cadena de texto' })
   country?: string;
 
   @Field({ nullable: true })
   @IsOptional()
-  @IsBoolean()
+  @IsBoolean({ message: 'available debe ser booleano' })
   available?: boolean;
 
   @Field({ nullable: true })
   @IsOptional()
-  @IsBoolean()
+  @IsBoolean({ message: 'hasMic debe ser booleano' })
   hasMic?: boolean;
 
   @Field({ nullable: true })
   @IsOptional()
-  @IsBoolean()
+  @IsBoolean({ message: 'showGamerTag debe ser booleano' })
   showGamerTag?: boolean;
 
   @Field()
-  @IsBoolean()
+  @IsBoolean({ message: 'termsAccepted debe ser booleano' })
   termsAccepted: boolean;
 
   @Field(() => [String], { nullable: true })
   @IsOptional()
-  @IsArray()
-  @IsUrl({}, { each: true })
+  @IsArray({ message: 'photos debe ser un arreglo' })
+  @IsUrl({}, { each: true, message: 'Cada foto debe ser una URL válida' })
   photos?: string[];
 }

--- a/src/users/application/dto/find-user-by-email.input.ts
+++ b/src/users/application/dto/find-user-by-email.input.ts
@@ -4,8 +4,8 @@ import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
 @InputType()
 export class FindUserByEmailInput {
   @Field()
-  @IsEmail()
-  @IsString()
-  @IsNotEmpty()
+  @IsEmail({}, { message: 'El correo electrónico no es válido' })
+  @IsString({ message: 'El correo electrónico debe ser una cadena de texto' })
+  @IsNotEmpty({ message: 'El correo electrónico es obligatorio' })
   email: string;
 }


### PR DESCRIPTION
## Summary
- add custom validation messages to CreateUserInput
- add custom validation messages to user search input
- improve create and update game DTOs with messages
- create GraphQLExceptionFilter to format errors
- enable GraphQLExceptionFilter in `main.ts`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840a174f158832a9cb5ab121878ea88